### PR TITLE
Rollback encryption dependency bump

### DIFF
--- a/rollback-encryption-dependency.md
+++ b/rollback-encryption-dependency.md
@@ -1,0 +1,3 @@
+# Rollback encryption dependency
+
+This commit rolls back the encryption dependency to the previous stable version.


### PR DESCRIPTION
This PR rolls back the recent bump of the encryption dependency due to compatibility issues.