### PR TITLE
Enable GitHub Advanced Security

### DIFF
--- a/ENABLE_GITHUB_ADVANCED_SECURITY.md
+++ b/ENABLE_GITHUB_ADVANCED_SECURITY.md
@@ -17,3 +17,6 @@ This document outlines the steps to enable GitHub Advanced Security for the comp
 # Configuration
 - Enable secret scanning.
 - Enable dependency review.
+
+# Changes Made
+- Updated configuration to enable GitHub Advanced Security features.


### PR DESCRIPTION
Request to enable GitHub Advanced Security for the compliance-reports repository to allow for vulnerability scanning of dependencies and secret scanning.