### PR TITLE
Bump dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,10 @@
-module compliance-reports\n\ngo 1.20\n\nrequire (\n	github.com/gorilla/mux latest\n	github.com/stretchr/testify latest\n)
+module compliance-reports
+
+go 1.21
+
+require (
+
+github.com/gorilla/mux v1.8.5
+
+github.com/stretchr/testify v1.8.1
+)


### PR DESCRIPTION
Updated Go version to 1.21 and pinned dependencies to specific versions to avoid using 'latest'.